### PR TITLE
Remove the build admin notice

### DIFF
--- a/augmented-reality.php
+++ b/augmented-reality.php
@@ -21,22 +21,3 @@ require_once dirname( __FILE__ ) . '/vendor/autoload.php';
 
 $plugin = new Plugin();
 $plugin->init();
-
-/**
- * Adds an admin notice if the Composer autoload file is not present.
- * Mainly taken from the Official AMP Plugin for WordPress.
- *
- * @see https://github.com/ampproject/amp-wp/blob/9a651b11baae1d9746a3af1f6998ef0b9c0689b2/amp.php#L72
- */
-function _augmented_reality_build_notice() {
-	?>
-	<div class="notice notice-error">
-		<p><?php esc_html_e( 'It looks like the Augmented Reality plugin is not built. Please run `composer install && npm install && npm run dev`.', 'augmented-reality' ); ?></p>
-	</div>
-	<?php
-}
-
-if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) || ! file_exists( __DIR__ . '/build/index.js' ) ) {
-	add_action( 'admin_notices', 'AugmentedReality\\_augmented_reality_build_notice' );
-	return;
-}


### PR DESCRIPTION
* This was mainly taken from the AMP plugin
* In the AMP plugin, that block is essentially removed on building it, but this plugin doesn't have that step
* Removing this is probably the simplest approach