### PR TITLE
Remove an extra space at the top of index.js, fix typo

### DIFF
--- a/php/class-block.php
+++ b/php/class-block.php
@@ -111,7 +111,7 @@ class Block {
 		$real_mime = finfo_file( $finfo, $file );
 		finfo_close( $finfo );
 
-		// .obj and .mtl files can have a $real_mime of 'text/plain', so allow that tile type.
+		// .obj and .mtl files can have a $real_mime of 'text/plain', so allow that file type.
 		if ( 'text/plain' === $real_mime ) {
 			if ( $ob_match ) {
 				$wp_check_filetype_and_ext['ext']  = 'obj';

--- a/src/blocks/ar-viewer/index.js
+++ b/src/blocks/ar-viewer/index.js
@@ -1,4 +1,3 @@
-
 /**
  * WordPress dependencies
  */


### PR DESCRIPTION
* There was a misspelling, where 'file' was spelled 'tile.'
* Also, fix an extra space at the top of `index.js`.