### PR TITLE
Set renovate.json as an empty object

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,1 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}
+{}


### PR DESCRIPTION
Like [in the AMP plugin](https://github.com/ampproject/amp-wp/blob/0c7ba2b46390420ca0c6dee069d0ae5322b3084f/renovate.json), maybe this will correct the error in #18:

```sh
Command failed: composer update brain/monkey brainmaestro/composer-git-hooks dealerdirect/phpcodesniffer-composer-installer xwp/wp-dev-lib --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader
/bin/sh: 1: composer: not found
```
