### PR TITLE
Add lint:js:files script for pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dev": "wp-scripts start",
     "lint": "npm-run-all --parallel lint:*",
     "lint:js": "wp-scripts lint-js src",
+    "lint:js:files": "wp-scripts lint-js",
     "lint:js:fix": "npm run lint:js -- --fix",
     "lint:pkg-json": "wp-scripts lint-pkg-json",
     "lint:php": "vendor/bin/phpcs",


### PR DESCRIPTION
* Lints only the files passed to it, not all files, like `lint:js`
* This is needed to run the JS pre-commit hook
