### PR TITLE
Try using Enzyme instead of React Testing Library

### DIFF
--- a/js/src/block/edit.test.js
+++ b/js/src/block/edit.test.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import '@testing-library/jest-dom/extend-expect';
-import { render, screen } from '@testing-library/react';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -20,37 +19,37 @@ jest.mock( '@wordpress/block-editor', () => {
 
 const baseProps = { attributes: {} };
 const setup = ( props ) => {
-	return render( <Edit { ...props } /> );
+	return mount( <Edit { ...props } /> );
 };
 
 describe( 'Edit', () => {
-	it( 'displays the color pallete text', () => {
-		setup( baseProps );
-		expect( screen.getByText( 'Background Color' ) ).toBeInTheDocument();
+	it( 'displays the color palette text', () => {
+		const rendered = setup( baseProps );
+		expect( rendered.contains( 'Background Color' ) ).toEqual( true );
 	} );
 
 	it( 'displays the instructions, even if there is no url or id', () => {
-		setup( baseProps );
-		expect( screen.getByText( 'Upload a model file, or choose one from your media library' ) ).toBeInTheDocument();
+		const rendered = setup( baseProps );
+		expect( rendered.contains( 'Upload a model file, or choose one from your media library' ) ).toEqual( true );
 	} );
 
 	it.each( [
 		[ 'https://foo.com', 'Edit model' ],
 		[ '', 'Model' ],
 	] )( 'displays the correct title, depending on whether there is a url', ( url, expectedTitle ) => {
-		setup( { attributes: { url } } );
-		expect( screen.getByText( expectedTitle ) ).toBeInTheDocument();
+		const rendered = setup( { attributes: { url } } );
+		expect( rendered.contains( expectedTitle ) ).toEqual( true );
 	} );
 
 	it( 'does not display a preview of the model-viewer if there is no url', () => {
-		setup( baseProps );
-		expect( document.getElementsByTagName( 'model-viewer' ) ).toHaveLength( 0 );
+		const rendered = setup( baseProps );
+		expect( rendered.find( 'model-viewer' ) ).toHaveLength( 0 );
 	} );
 
 	it( 'displays a preview of the model-viewer if there is a url', () => {
-		setup( { attributes: { url: 'https://baz.com' } } );
+		const rendered = setup( { attributes: { url: 'https://baz.com' } } );
 
-		const modelViewer = document.getElementsByTagName( 'model-viewer' );
+		const modelViewer = rendered.find( 'model-viewer' );
 		expect( modelViewer ).toHaveLength( 1 );
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@wordpress/eslint-plugin": "3.3.0",
     "@wordpress/i18n": "3.9.0",
     "@wordpress/scripts": "6.2.0",
+    "enzyme": "3.11.0",
     "eslint": "6.8.0",
     "eslint-plugin-eslint-comments": "3.1.2",
     "eslint-plugin-import": "2.20.1",


### PR DESCRIPTION
* Experiment with using [Enzyme](https://airbnb.io/enzyme/) instead of [React Testing Library](https://testing-library.com/docs/react-testing-library/intro)
* This seems to be very similar, but maybe because these tests are simple
* These are trivial changes
* Shallow-rendering didn't work, as this component has important [child components](https://github.com/kienstra/augmented-reality/blob/61f78f271f531aef3d179e44414e2f3857065d34/js/src/block/edit.js#L19-L52). So this uses `mount()` instead of `shallow()`.