### PR TITLE
Allow uploading the MIME type of .glb files

### DIFF
--- a/js/src/block/edit.js
+++ b/js/src/block/edit.js
@@ -13,6 +13,7 @@ const Edit = ( { attributes: { autoRotate, backgroundColor, className, id, url }
 		title: !! url ? __( 'Edit model', 'augmented-reality' ) : __( 'Model', 'augmented-reality' ),
 		instructions: __( 'Upload a model file, or choose one from your media library', 'augmented-reality' ),
 	};
+	const allowedMimeTypes = [ 'application/glb', 'model/gltf+json' ];
 
 	return (
 		<>
@@ -39,7 +40,8 @@ const Edit = ( { attributes: { autoRotate, backgroundColor, className, id, url }
 			</InspectorControls>
 			<div className={ className }>
 				<MediaPlaceholder
-					allowedTypes={ [ 'application/glb' ] }
+					accept={ allowedMimeTypes.join() }
+					allowedTypes={ allowedMimeTypes }
 					onSelect={ ( newMedia ) => {
 						setAttributes( {
 							url: newMedia.url,

--- a/php/Block.php
+++ b/php/Block.php
@@ -43,6 +43,7 @@ class Block {
 	public function init() {
 		add_action( 'init', [ $this, 'register_block' ] );
 		add_action( 'wp_check_filetype_and_ext', [ $this, 'check_filetype_and_ext' ], 10, 3 );
+		add_filter( 'upload_mimes', [ $this, 'add_mime_type' ] );
 	}
 
 	/**
@@ -102,7 +103,7 @@ class Block {
 	 * Allow uploading a .gbl file, as it's normally not allowed.
 	 *
 	 * @param array  $wp_check_filetype_and_ext {
-	 *      The file data.
+	 *     The file data.
 	 *
 	 *     @type string    $ext The file extension.
 	 *     @type string    $type The file type.
@@ -126,5 +127,19 @@ class Block {
 		$wp_check_filetype_and_ext['type'] = 'application/octet-stream';
 
 		return $wp_check_filetype_and_ext;
+	}
+
+	/**
+	 * Add the MIME type for the model.
+	 *
+	 * @param array $mimes The allowed MIME types.
+	 * @return array $mimes The MIME types, possibly with one added.
+	 */
+	public function add_mime_type( $mimes ) {
+		if ( current_user_can( 'edit_posts' ) ) {
+			$mimes['glb'] = 'model/gltf+json';
+		}
+
+		return $mimes;
 	}
 }

--- a/tests/php/TestBlock.php
+++ b/tests/php/TestBlock.php
@@ -112,4 +112,29 @@ class TestBlock extends TestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Test add_mime_type.
+	 *
+	 * @covers \AugmentedReality\Block::add_mime_type()
+	 */
+	public function test_add_mime_type() {
+		WP_Mock::userFunction( 'current_user_can' )
+			->once()
+			->with( 'edit_posts' )
+			->andReturn( true );
+
+		$original_mime_types = [
+			'jpeg' => 'image/jpeg',
+			'png'  => 'image/png',
+		];
+
+		$this->assertEquals(
+			array_merge(
+				$original_mime_types,
+				[ 'glb' => 'model/gltf+json' ]
+			),
+			$this->instance->add_mime_type( $original_mime_types )
+		);
+	}
 }


### PR DESCRIPTION
* Adds a PHP filter to allow this type
* Adds an `accept` prop to [MediaPlaceholder](https://github.com/WordPress/gutenberg/blob/8d661ce7517a0e9a59bd381f88197abac5e6ed01/packages/block-editor/src/components/media-placeholder/index.js), with this MIME type