### PR TITLE
Fix typos in backgroundColor and type

### DIFF
--- a/php/Block.php
+++ b/php/Block.php
@@ -61,8 +61,8 @@ class Block {
 						'id'              => [
 							'type' => 'number',
 						],
-						'backgroudnColor' => [
-							'tyep' => 'string',
+						'backgroundColor' => [
+							'type' => 'string',
 						],
 					],
 					'render_callback' => [ $this, 'render_block' ],


### PR DESCRIPTION
* Fixes spelling of `backgroundColor` and `type`