### PR TITLE
Import from WordPress packages, instead of using const destructuring

### DIFF
--- a/js/src/block/edit.test.js
+++ b/js/src/block/edit.test.js
@@ -9,7 +9,7 @@ import { render, screen } from '@testing-library/react';
  */
 import Edit from './edit';
 
-// Mocks the <InpectorControls> component only, so that the other components in this package behave as usual.
+// Mocks the <InspectorControls> component only, so that the other components in this package behave as usual.
 jest.mock( '@wordpress/block-editor', () => {
 	const original = require.requireActual( '@wordpress/block-editor' );
 	return {

--- a/js/src/block/index.js
+++ b/js/src/block/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-const { __ } = wp.i18n;
-const { registerBlockType } = wp.blocks;
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/php/Asset.php
+++ b/php/Asset.php
@@ -77,7 +77,7 @@ class Asset {
 	 */
 	public function enqueue_script( $slug ) {
 		$config = $this->get_script_config( self::MODEL_VIEWER_JS_SLUG );
-		\wp_enqueue_script(
+		wp_enqueue_script(
 			$this->get_prefixed_slug( $slug ),
 			$this->plugin->get_script_path( $slug ),
 			$config['dependencies'],

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -87,7 +87,7 @@ class Plugin {
 	 * Inits the plugin classes.
 	 */
 	public function init_classes() {
-		$this->components = new \stdClass();
+		$this->components = new stdClass();
 		foreach ( $this->classes as $class ) {
 			$class_with_namespace     = __NAMESPACE__ . '\\' . $class;
 			$this->components->$class = new $class_with_namespace( $this );


### PR DESCRIPTION
* This means less dependence on the environment. 
* It ensures that a certain version of the package is used.